### PR TITLE
V1.1.4

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,10 +1,10 @@
 {
-  "name": "generate_bed_v1.1.3",
-  "title": "generate_bed_v1.1.3",
+  "name": "generate_bed_v1.1.4",
+  "title": "generate_bed_v1.1.4",
   "summary": "Generates a BED file for a given panel name",
   "dxapi": "1.0.0",
   "properties": {
-  "githubRelease": "v1.1.3"
+  "githubRelease": "v1.1.4"
 },
   "inputSpec": [
     {

--- a/resources/home/dnanexus/generate_bed.py
+++ b/resources/home/dnanexus/generate_bed.py
@@ -180,11 +180,11 @@ def generate_bed(
         # Add if statement to minimise long output_prefix as
         # dnanexus cannot handle long filenames
         length_panels = sum(len(i) for i in panels)
-        length_dividers = (len(panels) -1) * 2
+        length_dividers = (len(panels) - 1) * 2
         length_output = length_panels + length_dividers
         print("Length of output prefix: " + str(length_output))
 
-        if length_output > 255:
+        if length_output > 247:
             output_prefix = "".join(panels[0:3])
             output_prefix = output_prefix + "_+" + \
                             str(len(panels)-3) + "others"

--- a/resources/home/dnanexus/generate_bed.py
+++ b/resources/home/dnanexus/generate_bed.py
@@ -187,7 +187,7 @@ def generate_bed(
         if length_output > 247:
             output_prefix = "".join(panels[0:3])
             output_prefix = output_prefix + "_+" + \
-                            str(len(panels)-3) + "others"
+            str(len(panels)-3) + "others"
         else:
             output_prefix = "&&".join(panels)
 

--- a/resources/home/dnanexus/generate_bed.py
+++ b/resources/home/dnanexus/generate_bed.py
@@ -186,7 +186,7 @@ def generate_bed(
 
         if length_output > 255:
             output_prefix = "".join(panels[0:3])
-            output_prefix = output_prefix + "_" + str(len(panels)-3) + "others"
+            output_prefix = output_prefix + "_+" + str(len(panels)-3) + "others"
         else:
             output_prefix = "&&".join(panels)
 

--- a/resources/home/dnanexus/generate_bed.py
+++ b/resources/home/dnanexus/generate_bed.py
@@ -177,7 +177,18 @@ def generate_bed(
     panels = [x.replace("/", "-") for x in panels]
 
     if not output_prefix:
-        output_prefix = "&&".join(panels)
+        # Add if statement to minimise output_prefix is long as 
+        # dnanexus cannot handle long filenames
+        length_panels = sum(len(i) for i in panels)
+        length_dividers = (len(panels) -1)*2
+        length_output = length_panels + length_dividers
+        print("Length of output prefix: " + str(length_output))
+
+        if length_output > 255:
+            output_prefix = "".join(panels[0:3])
+            output_prefix = output_prefix + "_" + str(len(panels)-3) + "others"
+        else:
+            output_prefix = "&&".join(panels)
 
     if build38:
         outfile = output_prefix + "_b38.bed"

--- a/resources/home/dnanexus/generate_bed.py
+++ b/resources/home/dnanexus/generate_bed.py
@@ -187,7 +187,7 @@ def generate_bed(
         if length_output > 247:
             output_prefix = "".join(panels[0:3])
             output_prefix = output_prefix + "_+" + \
-                            str(len(panels)-3) + "others"
+                    str(len(panels)-3) + "others"
         else:
             output_prefix = "&&".join(panels)
 

--- a/resources/home/dnanexus/generate_bed.py
+++ b/resources/home/dnanexus/generate_bed.py
@@ -177,7 +177,7 @@ def generate_bed(
     panels = [x.replace("/", "-") for x in panels]
 
     if not output_prefix:
-        # Add if statement to minimise output_prefix is long as 
+        # Add if statement to minimise long output_prefix as 
         # dnanexus cannot handle long filenames
         length_panels = sum(len(i) for i in panels)
         length_dividers = (len(panels) -1)*2

--- a/resources/home/dnanexus/generate_bed.py
+++ b/resources/home/dnanexus/generate_bed.py
@@ -187,7 +187,7 @@ def generate_bed(
         if length_output > 247:
             output_prefix = "".join(panels[0:3])
             output_prefix = output_prefix + "_+" + \
-            str(len(panels)-3) + "others"
+                            str(len(panels)-3) + "others"
         else:
             output_prefix = "&&".join(panels)
 

--- a/resources/home/dnanexus/generate_bed.py
+++ b/resources/home/dnanexus/generate_bed.py
@@ -177,16 +177,17 @@ def generate_bed(
     panels = [x.replace("/", "-") for x in panels]
 
     if not output_prefix:
-        # Add if statement to minimise long output_prefix as 
+        # Add if statement to minimise long output_prefix as
         # dnanexus cannot handle long filenames
         length_panels = sum(len(i) for i in panels)
-        length_dividers = (len(panels) -1)*2
+        length_dividers = (len(panels) -1) * 2
         length_output = length_panels + length_dividers
         print("Length of output prefix: " + str(length_output))
 
         if length_output > 255:
             output_prefix = "".join(panels[0:3])
-            output_prefix = output_prefix + "_+" + str(len(panels)-3) + "others"
+            output_prefix = output_prefix + "_+" + \
+                            str(len(panels)-3) + "others"
         else:
             output_prefix = "&&".join(panels)
 


### PR DESCRIPTION
If bed filename is too long (longer than 255 characters), app fails. 
Added fix to limit list of genes so the output is now **_HGNC:174_HGNC:32700_HGNC:25244_+29others_b37.bed**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_bed/13)
<!-- Reviewable:end -->
