### PR TITLE
update readme to remove mention of a manifest or sample identifying files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,9 @@ This app requires the following files:
 - genepanels (from 001_Reference)
 - genes2transcripts (from 001_Reference)
 - exons (from 001_Reference)
-
-AND also either:
-
 - the panel(s) and / or genes(s) to generate the bed for as a semi-colon ";" separated string, with
     genes being prefixed with an underscore (i.e. DDG2P;_HGNC:4834)
 
-OR
-
-- bioinformatics manifest (from 001_Reference)
-
-- a sample identifying file (this is used to get the appropriate panel from the manifest for the sample,
-    this should be named X10000_ as the underscore is used to split and identify the sample). Any sample identifying file may be used (preferentially smaller to reduce download time).
 
 ## Optional inputs:
 - an "additional regions" file may be provided for a gene or panel. A .tsv file with column headers `chromosome, start, end, gene_panel, transcript` may be provided, where the `gene_panel` column should contain a HGNC gene ID or clinical indication and the `transcript` column should contain a description of the corresponding region. The regions specified in this file will be included in the outputted bed file. Additional columns are allowed with unique headers.


### PR DESCRIPTION
Changes 
- Update readme 
      - Reflect dxapp.json update which addresses github issue (https://github.com/eastgenomics/eggd_generate_bed/issues/30)
                      - removal of manifest files as input
                      - removal of sample identifying file as input

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_bed/35)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the required input format for generating BED files.
  * Updated guidance to show panel and/or gene values as a semi-colon separated string, with genes prefixed by an underscore.
  * Removed outdated alternative input options from the required inputs section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->