### PR TITLE
Di 3143 v1.3.1 final2 part d dev

### DIFF
--- a/src/eggd_generate_bed.sh
+++ b/src/eggd_generate_bed.sh
@@ -74,6 +74,7 @@ main() {
         sort -k1,1V -k2,2n "$bed_file" -o "temp_bed.bed"
         mv "temp_bed.bed" "$bed_file"
     elif [-s "$bed_file"] &&  [!-z "$header_info" ]
+    then
         sort -k1,1V -k2,2n "$bed_file" -o "temp_bed.bed"
         mv "temp_bed.bed" "$bed_file"   
         tmp_bed_with_header="$(mktemp)"

--- a/src/eggd_generate_bed.sh
+++ b/src/eggd_generate_bed.sh
@@ -69,20 +69,21 @@ main() {
         echo "empty bed file generated, exiting now."
         dx-jobutil-report-error "Error: empty bed file generated"
         exit 1
-    elif [-s "$bed_file"] &&  [-z "$header_info" ]
-    then
+    fi
+
+    if [ -s "$bed_file" ]; then
         sort -k1,1V -k2,2n "$bed_file" -o "temp_bed.bed"
-        mv "temp_bed.bed" "$bed_file"
-    elif [-s "$bed_file"] &&  [!-z "$header_info" ]
-    then
-        sort -k1,1V -k2,2n "$bed_file" -o "temp_bed.bed"
-        mv "temp_bed.bed" "$bed_file"   
-        tmp_bed_with_header="$(mktemp)"
-        {
-            printf '%s\n' "${header_info}"
-            cat "${bed_file}"
-        } > "${tmp_bed_with_header}"
-        mv "${tmp_bed_with_header}" "${bed_file}"
+        if [ -z "$header_info" ]; then
+            mv "temp_bed.bed" "$bed_file"
+        else
+            mv "temp_bed.bed" "$bed_file"   
+            tmp_bed_with_header="$(mktemp)"
+            {
+                printf '%s\n' "${header_info}"
+                cat "${bed_file}"
+            } > "${tmp_bed_with_header}"
+            mv "${tmp_bed_with_header}" "${bed_file}"
+        fi
     fi
 
     echo "Done, uploading BED file: $bed_file"

--- a/src/eggd_generate_bed.sh
+++ b/src/eggd_generate_bed.sh
@@ -69,9 +69,13 @@ main() {
         echo "empty bed file generated, exiting now."
         dx-jobutil-report-error "Error: empty bed file generated"
         exit 1
-    else
+    elif [-s "$bed_file"] &&  [-z "$header_info" ]
+    then
         sort -k1,1V -k2,2n "$bed_file" -o "temp_bed.bed"
         mv "temp_bed.bed" "$bed_file"
+    elif [-s "$bed_file"] &&  [!-z "$header_info" ]
+        sort -k1,1V -k2,2n "$bed_file" -o "temp_bed.bed"
+        mv "temp_bed.bed" "$bed_file"   
         tmp_bed_with_header="$(mktemp)"
         {
             printf '%s\n' "${header_info}"


### PR DESCRIPTION
Add logic to handle creating panel bed with and without header lines.

Sense check:
https://platform.dnanexus.com/panx/projects/J7Z8gyj46Z69p2gbZ4BPQq4Q/monitor/job/J95vB3j46Z6G3vYqQpx6bbYv

https://platform.dnanexus.com/panx/projects/J7Z8gyj46Z69p2gbZ4BPQq4Q/monitor/job/J95vJG846Z60z6b8PQ9qgVKG

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_bed/37)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BED file handling so existing non-empty files are sorted consistently before being saved.
  * Added support for preserving or prepending header information when generating the final BED output.
  * Avoids leaving BED output in an unexpected state when the file already contains data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->